### PR TITLE
Allow users to cancel fetching log streams

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -90,7 +90,7 @@ func (cwl *Client) Tail(ctx context.Context) error {
 		s.Start()
 		s.Suffix = " Fetching log streams..."
 
-		streams, err := cwl.ListStreams(logGroupName, cwl.config.StartTime.Unix()*1000)
+		streams, err := cwl.ListStreams(ctx, logGroupName, cwl.config.StartTime.Unix()*1000)
 		if err != nil {
 			return errors.Wrap(err, "Initial check failed")
 		}
@@ -165,7 +165,7 @@ func (cwl *Client) tail(ctx context.Context, logGroupName string,
 		case <-start:
 		}
 
-		streams, err := cwl.ListStreams(logGroupName, *lastSeenTime)
+		streams, err := cwl.ListStreams(ctx, logGroupName, *lastSeenTime)
 		if err != nil {
 			return err
 		}

--- a/cloudwatch/stream.go
+++ b/cloudwatch/stream.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"context"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -16,7 +17,7 @@ type LogStream struct {
 }
 
 // ListStreams lists stream names matching the specified filter
-func (cwl *Client) ListStreams(groupName string, since int64) (streams []*LogStream, err error) {
+func (cwl *Client) ListStreams(ctx context.Context, groupName string, since int64) (streams []*LogStream, err error) {
 	// If LogStreamNamePrefix is specified, log streams can not be sorted by LastEventTimestamp.
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/cloudwatchlogs/#DescribeLogStreamsInput
 	if cwl.config.LogStreamNamePrefix != "" {
@@ -54,7 +55,7 @@ func (cwl *Client) ListStreams(groupName string, since int64) (streams []*LogStr
 		input.Descending = aws.Bool(true)
 	}
 
-	err = cwl.client.DescribeLogStreamsPages(input, fn)
+	err = cwl.client.DescribeLogStreamsPagesWithContext(ctx, input, fn)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
 			if awsErr.Code() == "ResourceNotFoundException" {


### PR DESCRIPTION
I want to cancel fetching log streams if I forget to specify `--since` option.