### PR TITLE
Adds region cli flag

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -39,6 +39,9 @@ type logEvent struct {
 func NewClient(conf *config.Config) *Client {
 	opts := session.Options{
 		SharedConfigState: session.SharedConfigEnable,
+		Config: aws.Config{
+			Region: aws.String(conf.Region),
+		},
 	}
 	sess := session.Must(session.NewSessionWithOptions(opts))
 	return &Client{

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	LogStreamNameFilter *regexp.Regexp
 	LogStreamNamePrefix string
 	FilterPattern       string
+	Region              string
 	Timestamps          bool
 	EventID             bool
 	NoLogGroupName      bool
@@ -77,6 +78,7 @@ func New(c *cli.Context) (*Config, error) {
 		LogStreamNameFilter: regexp.MustCompile(logStreamName),
 		LogStreamNamePrefix: c.String("stream-prefix"),
 		FilterPattern:       c.String("filter"),
+		Region:              c.String("region"),
 		Timestamps:          c.Bool("timestamps"),
 		EventID:             c.Bool("event-id"),
 		NoLogGroupName:      c.Bool("no-log-group"),

--- a/main.go
+++ b/main.go
@@ -41,6 +41,11 @@ func main() {
 			Usage: "Return logs older than a relative duration like 0, 2m, or 3h.",
 		},
 		cli.StringFlag{
+			Name:  "region, r",
+			Value: "",
+			Usage: "Specify an AWS region.",
+		},
+		cli.StringFlag{
 			Name:  "filter",
 			Value: "",
 			Usage: "The filter pattern to use. For more information, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html.",


### PR DESCRIPTION
Adds the optional --region cli flag. Region can be specified with either -r or --region. Omitting a region will cause the utern cloudwatch client wrapper to pass an empty string to the session in aws-sdk-go which interprets the empty string appropriately. Usage of utern without a region specified continues to behave as expected, falling back to the default AWS region used by aws cli. Specifying an invalid region returns "no such host". 

This feature was requested in issue #1 and is something I personally wanted to use. Please let me know if you would like different behavior to merge or if there are any suggestions for improvement.