### PR TITLE
add --color option to force color output

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -49,6 +49,9 @@ func NewClient(conf *config.Config) *Client {
 
 // Tail tails log
 func (cwl *Client) Tail(ctx context.Context) error {
+	if cwl.config.Color {
+		c.NoColor = false
+	}
 	start := make(chan struct{}, 1)
 	ch := make(chan *logEvent, 1000)
 	errch := make(chan error)

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	NoLogGroupName      bool
 	NoLogStreamName     bool
 	MaxLength           int
+	Color               bool
 }
 
 // New returns Config
@@ -82,6 +83,7 @@ func New(c *cli.Context) (*Config, error) {
 		NoLogGroupName:      c.Bool("no-log-group"),
 		NoLogStreamName:     c.Bool("no-log-stream"),
 		MaxLength:           c.Int("max-length"),
+		Color:               c.Bool("color"),
 	}
 
 	return config, nil

--- a/main.go
+++ b/main.go
@@ -66,6 +66,10 @@ func main() {
 			Value: 0,
 			Usage: "Maximum log message length",
 		},
+		cli.BoolFlag{
+			Name:  "color",
+			Usage: "Force color output even if not a tty",
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {


### PR DESCRIPTION
Add a `--color` option to force coloring.

The "utern" detects if it is a terminal output and determines whether to color the output. I think this is smart and good behavior, but sometimes I want it to force coloring. For example, it is necessary when we pipe the output to filter tool like "[filt](https://github.com/k1LoW/filt)".