### PR TITLE
Fix spinner output to stderr

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -93,6 +93,7 @@ func (cwl *Client) Tail(ctx context.Context) error {
 		}
 
 		s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+		s.Writer = os.Stderr
 		s.Start()
 		s.Suffix = " Fetching log streams..."
 

--- a/cloudwatch/group.go
+++ b/cloudwatch/group.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
@@ -11,6 +12,7 @@ import (
 // ListGroups lists group names matching the specified filter
 func (cwl *Client) ListGroups() (groupNames []string, err error) {
 	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	s.Writer = os.Stderr
 	s.Start()
 	s.Suffix = " Fetching log groups..."
 	defer s.Stop()


### PR DESCRIPTION
# Before
There was a problem when handling raw logs with pipes. Because the output of spinner was stdout.

```console
$ utern --no-log-group --no-log-stream RDS | jq .
+ RDSOSMetrics
+ RDSOSMetrics › db-T7X6VABCCNHPRQEROUSDIRSTUU (2019-11-22T15:02:47+09:00)
parse error: Invalid numeric literal at line 1, column 4
```

# After
So I changed the output of spinner to stderr.

```console
$ ./utern --no-log-group --no-log-stream RDS | jq .
+ RDSOSMetrics
+ RDSOSMetrics › db-T7X6VABCCNHPRQEROUSDIRSTUU (2019-11-22T15:03:47+09:00)
{
  "engine": "MYSQL",
  "instanceID": "sugoi-db",
  "instanceResourceID": "db-T7X6VABCCNHPRQEROUSDIRSTUU",
  "timestamp": "2019-11-22T05:59:47Z",
  "version": 1,
  "uptime": "83 days, 07:20:09",
  "numVCPUs": 2,
  "cpuUtilization": {
    "guest": 0,
    "irq": 0,
```
