### PR TITLE
feat: add flags to specify aws profile and usage of MFA

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/briandowns/spinner"
@@ -42,6 +43,14 @@ func NewClient(conf *config.Config) *Client {
 		Config: aws.Config{
 			Region: aws.String(conf.Region),
 		},
+	}
+	if conf.Profile != "" {
+		opts.Profile = conf.Profile
+	}
+	if conf.MFA && conf.Code == "" {
+		opts.AssumeRoleTokenProvider = stscreds.StdinTokenProvider
+	} else if conf.Code != "" {
+		opts.AssumeRoleTokenProvider = func() (string, error) { return conf.Code, nil }
 	}
 	sess := session.Must(session.NewSessionWithOptions(opts))
 	return &Client{

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,9 @@ type Config struct {
 	LogStreamNameFilter *regexp.Regexp
 	LogStreamNamePrefix string
 	FilterPattern       string
+	Profile             string
+	MFA                 bool
+	Code                string
 	Region              string
 	Timestamps          bool
 	EventID             bool
@@ -79,6 +82,9 @@ func New(c *cli.Context) (*Config, error) {
 		LogStreamNameFilter: regexp.MustCompile(logStreamName),
 		LogStreamNamePrefix: c.String("stream-prefix"),
 		FilterPattern:       c.String("filter"),
+		Profile:             c.String("profile"),
+		MFA:                 c.Bool("mfa"),
+		Code:                c.String("code"),
 		Region:              c.String("region"),
 		Timestamps:          c.Bool("timestamps"),
 		EventID:             c.Bool("event-id"),

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,6 @@ type Config struct {
 	LogStreamNamePrefix string
 	FilterPattern       string
 	Profile             string
-	MFA                 bool
 	Code                string
 	Region              string
 	Timestamps          bool
@@ -83,7 +82,6 @@ func New(c *cli.Context) (*Config, error) {
 		LogStreamNamePrefix: c.String("stream-prefix"),
 		FilterPattern:       c.String("filter"),
 		Profile:             c.String("profile"),
-		MFA:                 c.Bool("mfa"),
 		Code:                c.String("code"),
 		Region:              c.String("region"),
 		Timestamps:          c.Bool("timestamps"),

--- a/main.go
+++ b/main.go
@@ -50,14 +50,10 @@ func main() {
 			Value: "",
 			Usage: "Specify an AWS profile.",
 		},
-		cli.BoolFlag{
-			Name:  "mfa",
-			Usage: "Specify if MFA authentication via stdin is used.",
-		},
 		cli.StringFlag{
 			Name:  "code",
 			Value: "",
-			Usage: "Specify MFA token code directly, if supplied mfa flag can be omitted.",
+			Usage: "Specify MFA token code directly (if applicable), instead of using stdin.",
 		},
 		cli.StringFlag{
 			Name:  "region, r",

--- a/main.go
+++ b/main.go
@@ -46,6 +46,20 @@ func main() {
 			Usage: "Return logs older than a relative duration like 0, 2m, or 3h.",
 		},
 		cli.StringFlag{
+			Name:  "profile",
+			Value: "",
+			Usage: "Specify an AWS profile.",
+		},
+		cli.BoolFlag{
+			Name:  "mfa",
+			Usage: "Specify if MFA authentication via stdin is used.",
+		},
+		cli.StringFlag{
+			Name:  "code",
+			Value: "",
+			Usage: "Specify MFA token code directly, if supplied mfa flag can be omitted.",
+		},
+		cli.StringFlag{
 			Name:  "region, r",
 			Value: "",
 			Usage: "Specify an AWS region.",


### PR DESCRIPTION
Was looking at a tool to tail cloudwatch logs and discovered your project. Thanks for the great work!

*Issue #, if available:*

Current implementation does not support specifying which AWS profile is used, although it can be derived from env vars.

Also does not support profile that uses assumed role with MFA enabled.

*Description of changes:*

Add flags for optionally specifying AWS profile "--profile XXX", using MFA via stdin "--mfa" or supplying token code directly "--code 123456".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
