### PR TITLE
Consider the case when log stream has no log events

### DIFF
--- a/cloudwatch/stream.go
+++ b/cloudwatch/stream.go
@@ -29,6 +29,13 @@ func (cwl *Client) ListStreams(ctx context.Context, groupName string, since int6
 		hasUpdatedStream := false
 		minLastIngestionTime := int64(math.MaxInt64)
 		for _, stream := range res.LogStreams {
+
+			// If there is no log event in the log stream, FirstEventTimestamp, LastEventTimestamp, LastIngestionTime, and UploadSequenceToken will be nil.
+			// This activity is not officially documented.
+			if stream.FirstEventTimestamp == nil || stream.LastEventTimestamp == nil || stream.LastIngestionTime == nil || stream.UploadSequenceToken == nil {
+				continue
+			}
+
 			if *stream.LastIngestionTime < minLastIngestionTime {
 				minLastIngestionTime = *stream.LastIngestionTime
 			}
@@ -36,7 +43,7 @@ func (cwl *Client) ListStreams(ctx context.Context, groupName string, since int6
 				continue
 			}
 			// Use LastIngestionTime because LastEventTimestamp is updated slowly...
-			if stream.LastIngestionTime == nil || *stream.LastIngestionTime < since {
+			if *stream.LastIngestionTime < since {
 				continue
 			}
 			hasUpdatedStream = true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- If the log stream has no log events, describe-log-stream output does not include LastIngestionTime, so it becomes panic due to nil pointer dereference。

*Reproduce*
```
# NG pattern
aws logs create-log-group --log-group-name test-log-group
aws logs create-log-stream --log-group-name test-log-group --log-stream-name test-log-stream
aws logs describe-log-streams --log-group-name test-log-group --log-stream-name test-log-stream
{
    "logStreams": [
        {
            "logStreamName": "test-log-stream",
            "creationTime": 1585056526451,
            "arn": "arn:aws:logs:ap-northeast-1::log-group:test-log-group:log-stream:test-log-stream",
            "storedBytes": 0
        }
    ]
}
aws logs get-log-events --log-group-name test-log-group --log-stream-name test-log-stream
{
    "events": [],
    "nextForwardToken": "hogehoge",
    "nextBackwardToken": fugafuga"
}
utern test-log-group
+ test-log-group
⠋ Fetching log streams... panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x14f82d6]

goroutine 1 [running]:
github.com/knqyf263/utern/cloudwatch.(*Client).ListStreams.func1(0xc000332cc0, 0xc0004c4c01, 0x10000c0004073e0)
	/home/travis/gopath/src/github.com/knqyf263/utern/cloudwatch/stream.go:32 +0xf6
github.com/aws/aws-sdk-go/service/cloudwatchlogs.(*CloudWatchLogs).DescribeLogStreamsPagesWithContext(0xc00000e040, 0x17b4da0, 0xc000089b40, 0xc0004896b0, 0xc0002cd4a8, 0x0, 0x0, 0x0, 0xc0002cd4c8, 0x14853f4)
	/home/travis/gopath/pkg/mod/github.com/aws/aws-sdk-go@v1.25.36/service/cloudwatchlogs/api.go:1666 +0x163
github.com/knqyf263/utern/cloudwatch.(*Client).ListStreams(0xc0000680b0, 0x17b4da0, 0xc000089b40, 0xc000374ff0, 0xe, 0x1710cb72770, 0x1b48838, 0x0, 0x0, 0x0, ...)
	/home/travis/gopath/src/github.com/knqyf263/utern/cloudwatch/stream.go:66 +0x1d2
github.com/knqyf263/utern/cloudwatch.(*Client).Tail(0xc0000680b0, 0x17b4da0, 0xc000089b40, 0xc000089b40, 0xc000200580)
	/home/travis/gopath/src/github.com/knqyf263/utern/cloudwatch/cloudwatch.go:100 +0x782
main.run(0xc0001f4e70, 0xc0001f4e70, 0x0)
	/home/travis/gopath/src/github.com/knqyf263/utern/main.go:121 +0x8f
main.main.func1(0xc0000d86e0, 0x0, 0x0)
	/home/travis/gopath/src/github.com/knqyf263/utern/main.go:90 +0x8d
github.com/urfave/cli.HandleAction(0x1557380, 0x1631ed8, 0xc0000d86e0, 0x0, 0x0)
	/home/travis/gopath/pkg/mod/github.com/urfave/cli@v1.22.1/app.go:523 +0xbe
github.com/urfave/cli.(*App).Run(0xc0001fe000, 0xc0000aa040, 0x2, 0x2, 0x0, 0x0)
	/home/travis/gopath/pkg/mod/github.com/urfave/cli@v1.22.1/app.go:285 +0x5df
main.main()
	/home/travis/gopath/src/github.com/knqyf263/utern/main.go:93 +0x907

# OK pattern

TIMESTAMP=$(node -e 'console.log(Date.now())')
aws logs put-log-events --log-group-name test-log-group --log-stream-name test-log-stream --log-events timestamp=$TIMESTAMP,message='test'
aws logs describe-log-streams --log-group-name test-log-group --log-stream-name test-log-stream
utern test-log-group
aws logs put-log-events --log-gm --log-events timestamp=$TIMESTAMP,message='test'g-strea
{
    "nextSequenceToken": "fuga"
}
aws logs describe-log-streams --log-group-name test-log-group --log-stream-name test-log-stream
{
    "logStreams": [
        {
            "logStreamName": "test-log-stream",
            "creationTime": 1585056526451,
            "firstEventTimestamp": 1585056572981,
            "lastEventTimestamp": 1585056572981,
            "lastIngestionTime": 1585056573954,
            "uploadSequenceToken": "mogamoga",
            "arn": "arn:aws:logs:ap-northeast-1:xxxxxxx:log-group:test-log-group:log-stream:test-log-stream",
            "storedBytes": 0
        }
    ]
}

utern test-log-group
+ test-log-group
+ test-log-group › test-log-stream (2020-03-24T22:29:33+09:00)
test-log-group test-log-stream test
```

