### PR TITLE
fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ sudo rpm -ivh https://github.com/knqyf263/utern/releases/download/v0.0.1/utern
 Download deb package from [the releases page](https://github.com/knqyf263/utern/releases)
 ```
 $ wget https://github.com/knqyf263/utern/releases/download/v0.0.1/utern_0.0.1_Tux_64-bit.deb
-$ sudo dpkg -i utern_0.0.1_linux_amd64.deb
+$ sudo dpkg -i utern_0.0.1_Tux_64-bit.deb
 ```
 
 # Examples


### PR DESCRIPTION
*Issue #, if available:*

Nothing.

*Description of changes:*

Fixed the README, which seems to have a different name for the deb package file when installing on Debian and Ubuntu. (actually, even though the version uses the latest one).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
