### PR TITLE
chore(actions): use a personal access token instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,4 +21,4 @@ jobs:
         version: latest
         args: release --rm-dist
       env:
-        GITHUB_TOKEN: ${{ secrets.github_token }}
+        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
The release for `homebrew-utern` is failing due to a lack of permission. This PR switches GITHUB_TOKEN to ACCESS_TOKEN registered as `Secrets`.
>⨯ release failed after 84.90s error=homebrew tap formula: failed to publish artifacts: PUT https://api.github.com/repos/knqyf263/homebrew-utern/contents/utern.rb: 403 Resource not accessible by integration []
