### PR TITLE
Improve performance when --since and --stream-prefix are specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,14 +167,24 @@ COMMANDS:
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --stream value, -n value         Log stream name (regular expression). Displays all if omitted. If the option "since" is set to recent time, this option usually makes it faster than the option "stream-prefix"
-   --stream-prefix value, -p value  Log stream name prefix. If a log group contains many log streams, this option makes it faster.
-   --since value, -s value          Return logs newer than a relative duration like 52, 2m, or 3h. (default: "5m")
-   --end value, -e value            Return logs older than a relative duration like 0, 2m, or 3h.
+   --stream value, -n value         Log stream name (regular expression).
+                                    Displays all if omitted. If the option
+                                    "since" is set to recent time, this option
+                                    usually makes it faster than the option
+                                    "stream-prefix"
+   --stream-prefix value, -p value  Log stream name prefix. If a log group
+                                    contains many log streams, this option makes
+                                    it faster.
+   --since value, -s value          Return logs newer than a relative duration
+                                    like 52, 2m, or 3h. (default: "5m")
+   --end value, -e value            Return logs older than a relative duration
+                                    like 0, 2m, or 3h.
    --profile value                  Specify an AWS profile.
-   --code value                     Specify MFA token code directly (if applicable), instead of using stdin.
+   --code value                     Specify MFA token code directly
+                                    (if applicable), instead of using stdin.
    --region value, -r value         Specify an AWS region.
-   --filter value                   The filter pattern to use. For more information, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html.
+   --filter value                   The filter pattern to use. For more
+                                    information, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html.
    --timestamps                     Print timestamps
    --event-id                       Print event ID
    --no-log-group                   Suppress display of log group name

--- a/README.md
+++ b/README.md
@@ -158,19 +158,21 @@ NAME:
    utern - Multi group and stream log tailing for AWS CloudWatch Logs
 
 USAGE:
-   utern [global options] log-group-query
+   utern [global options] command [command options] [arguments...]
 
 VERSION:
-   0.0.1
+   0.1.0
 
 COMMANDS:
-     help, h  Shows a list of commands or help for one command
+   help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --stream value, -n value         Log stream name (regular expression). Displays all if omitted.
-   --stream-prefix value, -p value  Log stream name prefix. If a log group contains many log streams, this option makesit faster.
+   --stream value, -n value         Log stream name (regular expression). Displays all if omitted. If the option "since" is set to recent time, this option usually makes it faster than the option "stream-prefix"
+   --stream-prefix value, -p value  Log stream name prefix. If a log group contains many log streams, this option makes it faster.
    --since value, -s value          Return logs newer than a relative duration like 52, 2m, or 3h. (default: "5m")
    --end value, -e value            Return logs older than a relative duration like 0, 2m, or 3h.
+   --profile value                  Specify an AWS profile.
+   --code value                     Specify MFA token code directly (if applicable), instead of using stdin.
    --region value, -r value         Specify an AWS region.
    --filter value                   The filter pattern to use. For more information, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html.
    --timestamps                     Print timestamps
@@ -181,7 +183,6 @@ GLOBAL OPTIONS:
    --color                          Force color output even if not a tty
    --help, -h                       show help
    --version, -v                    print the version
-
 ```
 
 # Contribute

--- a/cloudwatch/stream.go
+++ b/cloudwatch/stream.go
@@ -19,11 +19,6 @@ type LogStream struct {
 
 // ListStreams lists stream names matching the specified filter
 func (cwl *Client) ListStreams(ctx context.Context, groupName string, since int64) (streams []*LogStream, err error) {
-	// If LogStreamNamePrefix is specified, log streams can not be sorted by LastEventTimestamp.
-	// https://docs.aws.amazon.com/sdk-for-go/api/service/cloudwatchlogs/#DescribeLogStreamsInput
-	if cwl.config.LogStreamNamePrefix != "" {
-		since = 0
-	}
 	streams = []*LogStream{}
 	fn := func(res *cloudwatchlogs.DescribeLogStreamsOutput, lastPage bool) bool {
 		hasUpdatedStream := false
@@ -52,6 +47,8 @@ func (cwl *Client) ListStreams(ctx context.Context, groupName string, since int6
 				LastEventTimestamp: stream.LastIngestionTime,
 			})
 		}
+		// If LogStreamNamePrefix is specified, log streams can not be sorted by LastEventTimestamp.
+		// https://docs.aws.amazon.com/sdk-for-go/api/service/cloudwatchlogs/#DescribeLogStreamsInput
 		if cwl.config.LogStreamNamePrefix != "" {
 			return true
 		}

--- a/main.go
+++ b/main.go
@@ -29,22 +29,22 @@ func main() {
 		cli.StringFlag{
 			Name:  "stream, n",
 			Value: "",
-			Usage: "Log stream name (regular expression). Displays all if omitted. If the option \"since\" is set to recent time, this option usually makes it faster than the option \"stream-prefix\"",
+			Usage: "Log stream name (regular expression).\n\tDisplays all if omitted. If the option\n\t\"since\" is set to recent time, this option\n\tusually makes it faster than the option\n\t\"stream-prefix\"",
 		},
 		cli.StringFlag{
 			Name:  "stream-prefix, p",
 			Value: "",
-			Usage: "Log stream name prefix. If a log group contains many log streams, this option makes it faster.",
+			Usage: "Log stream name prefix. If a log group\n\tcontains many log streams, this option makes\n\tit faster.",
 		},
 		cli.StringFlag{
 			Name:  "since, s",
 			Value: "5m",
-			Usage: "Return logs newer than a relative duration like 52, 2m, or 3h.",
+			Usage: "Return logs newer than a relative duration\n\tlike 52, 2m, or 3h.",
 		},
 		cli.StringFlag{
 			Name:  "end, e",
 			Value: "",
-			Usage: "Return logs older than a relative duration like 0, 2m, or 3h.",
+			Usage: "Return logs older than a relative duration\n\tlike 0, 2m, or 3h.",
 		},
 		cli.StringFlag{
 			Name:  "profile",
@@ -54,7 +54,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "code",
 			Value: "",
-			Usage: "Specify MFA token code directly (if applicable), instead of using stdin.",
+			Usage: "Specify MFA token code directly\n\t(if applicable), instead of using stdin.",
 		},
 		cli.StringFlag{
 			Name:  "region, r",
@@ -64,7 +64,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "filter",
 			Value: "",
-			Usage: "The filter pattern to use. For more information, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html.",
+			Usage: "The filter pattern to use. For more\n\tinformation, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html.",
 		},
 		cli.BoolFlag{
 			Name:  "timestamps",

--- a/main.go
+++ b/main.go
@@ -29,12 +29,12 @@ func main() {
 		cli.StringFlag{
 			Name:  "stream, n",
 			Value: "",
-			Usage: "Log stream name (regular expression). Displays all if omitted.",
+			Usage: "Log stream name (regular expression). Displays all if omitted. If the option \"since\" is set to recent time, this option usually makes it faster than the option \"stream-prefix\"",
 		},
 		cli.StringFlag{
 			Name:  "stream-prefix, p",
 			Value: "",
-			Usage: "Log stream name prefix. If a log group contains many log streams, this option makes it faster.",
+			Usage: "Log stream name prefix. If a log group contains many log streams, this option makes it faster.",
 		},
 		cli.StringFlag{
 			Name:  "since, s",


### PR DESCRIPTION
*Description of changes:*

This PR improves the performance of ListStreams when both of the options "since" and "stream-prefix" are specified because utern only watches streams whose LastIngestionTime is greater than or equal to the option "since".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
