### PR TITLE
Fix bug that utern shows same logs repeatedly

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -39,7 +39,7 @@ func (c *EventCache) Load(logGroupName string, key *string) (ok bool) {
 		return false
 	}
 	cache := v.(map[string]*int64)
-	_, ok = cache[logGroupName]
+	_, ok = cache[*key]
 	return ok
 }
 


### PR DESCRIPTION
*Issue https://github.com/knqyf263/utern/issues/29*

*Description of changes:*

This PR fixes https://github.com/knqyf263/utern/issues/29.
The cause is that `EventCacheLoad` doesn't use the argument `key` to check if the cache exists or not.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
